### PR TITLE
Add four-page lifestyle survey sample document

### DIFF
--- a/moda-premium-survey-netlify/public/css/styles.css
+++ b/moda-premium-survey-netlify/public/css/styles.css
@@ -207,3 +207,178 @@ h2 {
   font-size: 48px;
   text-align: center;
 }
+
+/* Survey document layout */
+body.survey-doc {
+  background: #f0f1f7;
+}
+
+.survey-document {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  margin-bottom: 2rem;
+}
+
+.survey-page {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.75rem 2rem;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+  page-break-after: always;
+  break-after: page;
+}
+
+.survey-page:last-of-type {
+  page-break-after: auto;
+  break-after: auto;
+}
+
+.page-header {
+  margin-bottom: 1.25rem;
+}
+
+.page-header h2 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.15rem, 2.6vw, 1.5rem);
+}
+
+.page-instructions,
+.survey-overview {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.question-list {
+  display: grid;
+  gap: 1.5rem;
+  padding-left: 1.25rem;
+}
+
+.question-list > li {
+  list-style-position: outside;
+  padding-left: 0.5rem;
+}
+
+.question-text {
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+
+.muted {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.option-list {
+  display: grid;
+  gap: 0.5rem;
+  padding-left: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.option-list label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.option-list input {
+  accent-color: var(--brand);
+}
+
+.option-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+textarea[disabled] {
+  resize: vertical;
+  min-height: 60px;
+  font-family: inherit;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  background: #fdfdfd;
+  color: var(--muted);
+}
+
+.scale-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  text-align: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  padding: 0.75rem;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  background: #fafafa;
+}
+
+.rank-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.rank-list li {
+  font-weight: 500;
+}
+
+.likert-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.likert-table th,
+.likert-table td {
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.likert-table th[scope="row"] {
+  text-align: left;
+  font-weight: 600;
+}
+
+.link-card {
+  margin-top: 1.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.link-card .actions {
+  justify-content: flex-start;
+}
+
+@media (max-width: 640px) {
+  .survey-page {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .scale-grid {
+    font-size: 0.85rem;
+  }
+}
+
+@media print {
+  body.survey-doc {
+    background: #fff;
+  }
+
+  .site-header,
+  .site-footer {
+    padding: 0.5rem 0;
+  }
+
+  .survey-page {
+    box-shadow: none;
+    border-color: #cbd5f5;
+  }
+}

--- a/moda-premium-survey-netlify/public/index.html
+++ b/moda-premium-survey-netlify/public/index.html
@@ -31,6 +31,17 @@
         <button class="btn primary" type="submit">Start — Staff</button>
       </div>
     </form>
+    <section class="card link-card">
+      <h2>Need a full survey document?</h2>
+      <p class="subtitle">View the 4-page Moda Premium Lifestyle Survey sample.</p>
+      <p>
+        Perfect for printing or copying into Word and Google Docs with a mix of fun and
+        professional questions.
+      </p>
+      <div class="actions">
+        <a class="btn primary" href="lifestyle-survey.html">Open sample survey</a>
+      </div>
+    </section>
   </main>
   <footer class="site-footer">
     <small>&copy; 2025 Moda Center (example)</small>

--- a/moda-premium-survey-netlify/public/lifestyle-survey.html
+++ b/moda-premium-survey-netlify/public/lifestyle-survey.html
@@ -1,0 +1,455 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Moda Premium Lifestyle Survey — Sample Document</title>
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body class="survey-doc">
+  <header class="site-header">
+    <h1>Moda Premium Lifestyle Survey</h1>
+    <p class="subtitle">Sample 4-page survey document</p>
+    <p class="survey-overview">Use this reference layout to copy into your preferred document editor.</p>
+  </header>
+
+  <main class="container">
+    <article class="survey-document">
+      <section class="survey-page" aria-labelledby="page-1">
+        <header class="page-header">
+          <h2 id="page-1">Page 1 – Moda Premium Lifestyle Survey</h2>
+          <p class="page-instructions">Instructions: Please answer the following questions as accurately as possible. Select one option unless otherwise noted.</p>
+        </header>
+        <ol class="question-list">
+          <li>
+            <div class="question-text">How familiar are you with Moda Premium’s products and services?</div>
+            <ul class="option-list">
+              <li><label><input type="radio" name="p1q1" disabled /> Very familiar</label></li>
+              <li><label><input type="radio" name="p1q1" disabled /> Somewhat familiar</label></li>
+              <li><label><input type="radio" name="p1q1" disabled /> Heard of them</label></li>
+              <li><label><input type="radio" name="p1q1" disabled /> Not familiar at all</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Which of the following best describes your current relationship with Moda Premium?</div>
+            <ul class="option-list">
+              <li><label><input type="radio" name="p1q2" disabled /> Active subscriber</label></li>
+              <li><label><input type="radio" name="p1q2" disabled /> Occasional customer</label></li>
+              <li><label><input type="radio" name="p1q2" disabled /> Considering becoming a customer</label></li>
+              <li><label><input type="radio" name="p1q2" disabled /> Former customer</label></li>
+              <li><label><input type="radio" name="p1q2" disabled /> Not a customer</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">What is your preferred method for discovering new lifestyle brands? <span class="muted">(Select up to two.)</span></div>
+            <ul class="option-list">
+              <li><label><input type="checkbox" disabled /> Social media</label></li>
+              <li><label><input type="checkbox" disabled /> Email newsletters</label></li>
+              <li><label><input type="checkbox" disabled /> Friends/family</label></li>
+              <li><label><input type="checkbox" disabled /> Podcasts</label></li>
+              <li><label><input type="checkbox" disabled /> In-store events</label></li>
+              <li><label><input type="checkbox" disabled /> Influencer collaborations</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Please rate your overall satisfaction with premium lifestyle brands you currently use.</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p1q4" disabled /> Very satisfied</label></li>
+              <li><label><input type="radio" name="p1q4" disabled /> Satisfied</label></li>
+              <li><label><input type="radio" name="p1q4" disabled /> Neutral</label></li>
+              <li><label><input type="radio" name="p1q4" disabled /> Dissatisfied</label></li>
+              <li><label><input type="radio" name="p1q4" disabled /> Very dissatisfied</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">How likely are you to recommend Moda Premium to a colleague or friend?</div>
+            <div class="scale-grid" role="presentation" aria-hidden="true">
+              <span>1 – Not likely</span>
+              <span>2</span>
+              <span>3</span>
+              <span>4</span>
+              <span>5 – Extremely likely</span>
+            </div>
+          </li>
+          <li>
+            <div class="question-text">Which statement best reflects your priorities when choosing premium services?</div>
+            <ul class="option-list">
+              <li><label><input type="radio" name="p1q6" disabled /> Quality and craftsmanship come first</label></li>
+              <li><label><input type="radio" name="p1q6" disabled /> Personalized service is essential</label></li>
+              <li><label><input type="radio" name="p1q6" disabled /> Sustainability and ethics guide my decisions</label></li>
+              <li><label><input type="radio" name="p1q6" disabled /> Value for money is most important</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">On average, how much do you invest monthly in premium lifestyle products or services?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p1q7" disabled /> Under $50</label></li>
+              <li><label><input type="radio" name="p1q7" disabled /> $50–$149</label></li>
+              <li><label><input type="radio" name="p1q7" disabled /> $150–$299</label></li>
+              <li><label><input type="radio" name="p1q7" disabled /> $300–$499</label></li>
+              <li><label><input type="radio" name="p1q7" disabled /> $500+</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">What is one word you associate with “premium lifestyle”?</div>
+            <textarea rows="2" disabled placeholder="Write your response here"></textarea>
+          </li>
+          <li>
+            <div class="question-text">Which communication channels would you like Moda Premium to use for major announcements?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="checkbox" disabled /> SMS text</label></li>
+              <li><label><input type="checkbox" disabled /> Email</label></li>
+              <li><label><input type="checkbox" disabled /> Mobile app push</label></li>
+              <li><label><input type="checkbox" disabled /> Social media</label></li>
+              <li><label><input type="checkbox" disabled /> Mailed brochure</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Select the industries where you most expect premium experiences. <span class="muted">(Select all that apply.)</span></div>
+            <ul class="option-list option-grid">
+              <li><label><input type="checkbox" disabled /> Travel</label></li>
+              <li><label><input type="checkbox" disabled /> Fitness &amp; wellness</label></li>
+              <li><label><input type="checkbox" disabled /> Dining</label></li>
+              <li><label><input type="checkbox" disabled /> Fashion</label></li>
+              <li><label><input type="checkbox" disabled /> Home services</label></li>
+              <li><label><input type="checkbox" disabled /> Technology</label></li>
+            </ul>
+          </li>
+        </ol>
+      </section>
+
+      <section class="survey-page" aria-labelledby="page-2">
+        <header class="page-header">
+          <h2 id="page-2">Page 2 – Experiences &amp; Preferences</h2>
+          <p class="page-instructions">Instructions: Share your honest perspective on current experiences. Use the space provided for open-ended questions.</p>
+        </header>
+        <ol class="question-list" start="1">
+          <li>
+            <div class="question-text">Rate the quality of your most recent premium service experience.</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p2q1" disabled /> Outstanding</label></li>
+              <li><label><input type="radio" name="p2q1" disabled /> Above expectations</label></li>
+              <li><label><input type="radio" name="p2q1" disabled /> Met expectations</label></li>
+              <li><label><input type="radio" name="p2q1" disabled /> Below expectations</label></li>
+              <li><label><input type="radio" name="p2q1" disabled /> Poor</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Which perks would motivate you to upgrade a subscription tier? <span class="muted">(Rank from 1 = most motivating to 5 = least.)</span></div>
+            <ol class="rank-list">
+              <li>Exclusive events</li>
+              <li>Complimentary gifts</li>
+              <li>Personalized concierge</li>
+              <li>Priority booking</li>
+              <li>Extended warranties</li>
+            </ol>
+          </li>
+          <li>
+            <div class="question-text">How important are sustainability initiatives when you assess a premium brand?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p2q3" disabled /> Not important</label></li>
+              <li><label><input type="radio" name="p2q3" disabled /> Slightly important</label></li>
+              <li><label><input type="radio" name="p2q3" disabled /> Moderately important</label></li>
+              <li><label><input type="radio" name="p2q3" disabled /> Very important</label></li>
+              <li><label><input type="radio" name="p2q3" disabled /> Essential</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Please describe a memorable premium experience you’ve had and what made it stand out.</div>
+            <textarea rows="3" disabled placeholder="Write your response here"></textarea>
+          </li>
+          <li>
+            <div class="question-text">Indicate your interest in the following Moda Premium offerings. <span class="muted">(1 = Not interested, 5 = Very interested.)</span></div>
+            <table class="likert-table" aria-hidden="true">
+              <thead>
+                <tr>
+                  <th scope="col">Offering</th>
+                  <th scope="col">1</th>
+                  <th scope="col">2</th>
+                  <th scope="col">3</th>
+                  <th scope="col">4</th>
+                  <th scope="col">5</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">Curated seasonal boxes</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+                <tr>
+                  <th scope="row">VIP access to partner venues</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+                <tr>
+                  <th scope="row">Personalized lifestyle coaching</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+                <tr>
+                  <th scope="row">Members-only travel itineraries</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+              </tbody>
+            </table>
+          </li>
+          <li>
+            <div class="question-text">Do you prefer in-person consultations or virtual sessions for premium services?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p2q6" disabled /> Exclusively in-person</label></li>
+              <li><label><input type="radio" name="p2q6" disabled /> Mostly in-person</label></li>
+              <li><label><input type="radio" name="p2q6" disabled /> No preference</label></li>
+              <li><label><input type="radio" name="p2q6" disabled /> Mostly virtual</label></li>
+              <li><label><input type="radio" name="p2q6" disabled /> Exclusively virtual</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">How satisfied are you with the personalization offered by your current premium memberships?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p2q7" disabled /> Very satisfied</label></li>
+              <li><label><input type="radio" name="p2q7" disabled /> Satisfied</label></li>
+              <li><label><input type="radio" name="p2q7" disabled /> Neutral</label></li>
+              <li><label><input type="radio" name="p2q7" disabled /> Unsatisfied</label></li>
+              <li><label><input type="radio" name="p2q7" disabled /> Very unsatisfied</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">What is your favorite indulgent treat or activity after a productive week?</div>
+            <textarea rows="2" disabled placeholder="Write your response here"></textarea>
+          </li>
+          <li>
+            <div class="question-text">Have you ever attended a Moda Premium event?</div>
+            <ul class="option-list">
+              <li><label><input type="radio" name="p2q9" disabled /> Yes, multiple times</label></li>
+              <li><label><input type="radio" name="p2q9" disabled /> Yes, once</label></li>
+              <li><label><input type="radio" name="p2q9" disabled /> Not yet, but interested</label></li>
+              <li><label><input type="radio" name="p2q9" disabled /> No, and not interested</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">If you could add one fun perk to the Moda Premium membership, what would it be?</div>
+            <textarea rows="2" disabled placeholder="Write your response here"></textarea>
+          </li>
+        </ol>
+      </section>
+
+      <section class="survey-page" aria-labelledby="page-3">
+        <header class="page-header">
+          <h2 id="page-3">Page 3 – Wellness, Community, and Values</h2>
+          <p class="page-instructions">Instructions: Reflect on how Moda Premium can support your well-being and community engagement.</p>
+        </header>
+        <ol class="question-list" start="1">
+          <li>
+            <div class="question-text">How frequently do you engage in wellness activities (fitness, meditation, spa, etc.) each week?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p3q1" disabled /> 0 times</label></li>
+              <li><label><input type="radio" name="p3q1" disabled /> 1–2 times</label></li>
+              <li><label><input type="radio" name="p3q1" disabled /> 3–4 times</label></li>
+              <li><label><input type="radio" name="p3q1" disabled /> 5+ times</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Which wellness services should Moda Premium prioritize? <span class="muted">(Select all that apply.)</span></div>
+            <ul class="option-list option-grid">
+              <li><label><input type="checkbox" disabled /> Mindfulness programs</label></li>
+              <li><label><input type="checkbox" disabled /> Nutritional coaching</label></li>
+              <li><label><input type="checkbox" disabled /> Fitness classes</label></li>
+              <li><label><input type="checkbox" disabled /> Spa and relaxation</label></li>
+              <li><label><input type="checkbox" disabled /> Outdoor adventures</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Rate your agreement with the statement: “A strong sense of community increases my loyalty to a premium brand.”</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p3q3" disabled /> Strongly agree</label></li>
+              <li><label><input type="radio" name="p3q3" disabled /> Agree</label></li>
+              <li><label><input type="radio" name="p3q3" disabled /> Neutral</label></li>
+              <li><label><input type="radio" name="p3q3" disabled /> Disagree</label></li>
+              <li><label><input type="radio" name="p3q3" disabled /> Strongly disagree</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">How would you prefer to connect with other Moda Premium members?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="checkbox" disabled /> In-person meetups</label></li>
+              <li><label><input type="checkbox" disabled /> Virtual forums</label></li>
+              <li><label><input type="checkbox" disabled /> Exclusive travel groups</label></li>
+              <li><label><input type="checkbox" disabled /> Volunteer projects</label></li>
+              <li><label><input type="checkbox" disabled /> I prefer not to network</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Share a cause or nonprofit that aligns with your personal values.</div>
+            <textarea rows="2" disabled placeholder="Write your response here"></textarea>
+          </li>
+          <li>
+            <div class="question-text">What type of wellness content do you consume most often for motivation?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p3q6" disabled /> Podcasts</label></li>
+              <li><label><input type="radio" name="p3q6" disabled /> Video series</label></li>
+              <li><label><input type="radio" name="p3q6" disabled /> Articles/blogs</label></li>
+              <li><label><input type="radio" name="p3q6" disabled /> Social media posts</label></li>
+              <li><label><input type="radio" name="p3q6" disabled /> Live workshops</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Which of the following best describes your work-life balance right now?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p3q7" disabled /> Excellent</label></li>
+              <li><label><input type="radio" name="p3q7" disabled /> Good</label></li>
+              <li><label><input type="radio" name="p3q7" disabled /> Acceptable</label></li>
+              <li><label><input type="radio" name="p3q7" disabled /> Needs improvement</label></li>
+              <li><label><input type="radio" name="p3q7" disabled /> Overwhelmed</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Rate your interest in the following community initiatives. <span class="muted">(1 = Not interested, 5 = Highly interested.)</span></div>
+            <table class="likert-table" aria-hidden="true">
+              <thead>
+                <tr>
+                  <th scope="col">Initiative</th>
+                  <th scope="col">1</th>
+                  <th scope="col">2</th>
+                  <th scope="col">3</th>
+                  <th scope="col">4</th>
+                  <th scope="col">5</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">Local volunteer days</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+                <tr>
+                  <th scope="row">Member-led clubs (e.g., book, wine)</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+                <tr>
+                  <th scope="row">Expert-led masterclasses</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+                <tr>
+                  <th scope="row">Social impact investing briefings</th>
+                  <td></td><td></td><td></td><td></td><td></td>
+                </tr>
+              </tbody>
+            </table>
+          </li>
+          <li>
+            <div class="question-text">Would you participate in a quarterly Moda Premium wellness challenge?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p3q9" disabled /> Definitely</label></li>
+              <li><label><input type="radio" name="p3q9" disabled /> Probably</label></li>
+              <li><label><input type="radio" name="p3q9" disabled /> Unsure</label></li>
+              <li><label><input type="radio" name="p3q9" disabled /> Probably not</label></li>
+              <li><label><input type="radio" name="p3q9" disabled /> Definitely not</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Describe one small change Moda Premium could make to enhance your daily routine.</div>
+            <textarea rows="2" disabled placeholder="Write your response here"></textarea>
+          </li>
+        </ol>
+      </section>
+
+      <section class="survey-page" aria-labelledby="page-4">
+        <header class="page-header">
+          <h2 id="page-4">Page 4 – Innovation, Feedback, and Closing</h2>
+          <p class="page-instructions">Instructions: Help us shape the next phase of Moda Premium services. Provide candid feedback.</p>
+        </header>
+        <ol class="question-list" start="1">
+          <li>
+            <div class="question-text">How do you prefer to receive updates about new product innovations?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p4q1" disabled /> Interactive webinars</label></li>
+              <li><label><input type="radio" name="p4q1" disabled /> Email briefings</label></li>
+              <li><label><input type="radio" name="p4q1" disabled /> Short videos</label></li>
+              <li><label><input type="radio" name="p4q1" disabled /> Podcast episodes</label></li>
+              <li><label><input type="radio" name="p4q1" disabled /> Printed lookbooks</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">What emerging technologies are you most excited to see integrated into premium services?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="checkbox" disabled /> AI-driven personalization</label></li>
+              <li><label><input type="checkbox" disabled /> Augmented reality experiences</label></li>
+              <li><label><input type="checkbox" disabled /> Smart home automation</label></li>
+              <li><label><input type="checkbox" disabled /> Sustainable materials</label></li>
+              <li><label><input type="checkbox" disabled /> Blockchain loyalty programs</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Rate your level of trust in Moda Premium to safeguard your personal data.</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p4q3" disabled /> Complete trust</label></li>
+              <li><label><input type="radio" name="p4q3" disabled /> High trust</label></li>
+              <li><label><input type="radio" name="p4q3" disabled /> Moderate trust</label></li>
+              <li><label><input type="radio" name="p4q3" disabled /> Low trust</label></li>
+              <li><label><input type="radio" name="p4q3" disabled /> No trust</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Which statement best reflects your openness to beta testing new Moda Premium offerings?</div>
+            <ul class="option-list">
+              <li><label><input type="radio" name="p4q4" disabled /> Enthusiastic early adopter</label></li>
+              <li><label><input type="radio" name="p4q4" disabled /> Interested with incentives</label></li>
+              <li><label><input type="radio" name="p4q4" disabled /> Curious but cautious</label></li>
+              <li><label><input type="radio" name="p4q4" disabled /> Prefer polished releases only</label></li>
+              <li><label><input type="radio" name="p4q4" disabled /> Not interested</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Please provide feedback on our pricing structure.</div>
+            <textarea rows="3" disabled placeholder="Write your response here"></textarea>
+          </li>
+          <li>
+            <div class="question-text">When evaluating premium brands, how important are fun or playful elements (e.g., surprise boxes, gamified rewards)?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p4q6" disabled /> Very important</label></li>
+              <li><label><input type="radio" name="p4q6" disabled /> Somewhat important</label></li>
+              <li><label><input type="radio" name="p4q6" disabled /> Neutral</label></li>
+              <li><label><input type="radio" name="p4q6" disabled /> Slightly important</label></li>
+              <li><label><input type="radio" name="p4q6" disabled /> Not important</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Select the top three areas where Moda Premium should invest in the next year.</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="checkbox" disabled /> Digital member experience</label></li>
+              <li><label><input type="checkbox" disabled /> Exclusive partnerships</label></li>
+              <li><label><input type="checkbox" disabled /> Wellness innovation</label></li>
+              <li><label><input type="checkbox" disabled /> Global expansion</label></li>
+              <li><label><input type="checkbox" disabled /> Community impact</label></li>
+              <li><label><input type="checkbox" disabled /> Luxury travel services</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">How satisfied are you with the overall communication clarity from Moda Premium?</div>
+            <ul class="option-list option-grid">
+              <li><label><input type="radio" name="p4q8" disabled /> Very satisfied</label></li>
+              <li><label><input type="radio" name="p4q8" disabled /> Satisfied</label></li>
+              <li><label><input type="radio" name="p4q8" disabled /> Neutral</label></li>
+              <li><label><input type="radio" name="p4q8" disabled /> Dissatisfied</label></li>
+              <li><label><input type="radio" name="p4q8" disabled /> Very dissatisfied</label></li>
+            </ul>
+          </li>
+          <li>
+            <div class="question-text">Do you have any concerns about continuing or starting a Moda Premium membership?</div>
+            <ul class="option-list">
+              <li><label><input type="radio" name="p4q9" disabled /> None at this time</label></li>
+              <li><label><input type="radio" name="p4q9" disabled /> Yes (please describe below)</label></li>
+            </ul>
+            <textarea rows="2" disabled placeholder="If yes, please explain"></textarea>
+          </li>
+          <li>
+            <div class="question-text">Final thoughts: What would make Moda Premium your go-to partner for premium lifestyle services?</div>
+            <textarea rows="3" disabled placeholder="Write your response here"></textarea>
+          </li>
+        </ol>
+      </section>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <small>&copy; 2025 Moda Center (example)</small>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated lifestyle-survey.html page that renders the four-page Moda Premium Lifestyle Survey sample document with interactive-looking inputs disabled for easy copying
- extend global styles to support the printable survey layout, question grids, and reference tables
- promote the sample document from the landing page with a new call-to-action card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d41eb3f8388330b042340e058b9f06